### PR TITLE
Add server online status flags

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -3,3 +3,5 @@ table { border-collapse: collapse; width: 100%; }
 th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
 .controls { margin-bottom: 10px; }
 button { margin-right: 4px; }
+.up { color: green; }
+.down { color: red; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -59,8 +59,14 @@ function updateStatus() {
       rows.forEach((row, i) => {
         const tr = document.querySelector(`tr[data-index="${i}"]`);
         if (!tr) return;
-        tr.querySelector('.primary-ip').textContent = row.primary_ip;
-        tr.querySelector('.ipmi-ip').textContent = row.ipmi_ip;
+        const primaryCell = tr.querySelector('.primary-ip');
+        const ipmiCell = tr.querySelector('.ipmi-ip');
+        primaryCell.textContent = row.primary_ip;
+        ipmiCell.textContent = row.ipmi_ip;
+        primaryCell.classList.toggle('up', row.primary_up === true);
+        primaryCell.classList.toggle('down', row.primary_up === false);
+        ipmiCell.classList.toggle('up', row.ipmi_up === true);
+        ipmiCell.classList.toggle('down', row.ipmi_up === false);
         tr.querySelector('.last-primary').textContent = row.last_primary !== null ? row.last_primary + 's' : '';
         tr.querySelector('.last-ipmi').textContent = row.last_ipmi !== null ? row.last_ipmi + 's' : '';
       });


### PR DESCRIPTION
## Summary
- track if primary or IPMI IP is reachable
- expose reachability via `/status` endpoint and color cells accordingly
- show online status using green/red styles

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_b_6846e6490cec832f9efef4d60792b1ba