### PR TITLE
Add start script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ An Express implementation is available in `server.js`.
    ```
 2. Start the server
    ```bash
-   node server.js
+   npm start
    ```
 
 The routes mirror the Flask version and files are saved in the same `uploads` directory.

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "ip-monitor",
   "version": "1.0.0",
   "description": "This simple web application allows you to upload a CSV or XLSX file with server information and monitor reachability of the server IP addresses.",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- set `main` entry to `server.js`
- add an npm `start` script
- document running the Node.js version via `npm start`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68527d5678f0832fb08cb84c73674df7