### PR TITLE
Remove unused variable in export route

### DIFF
--- a/server.js
+++ b/server.js
@@ -164,7 +164,6 @@ app.post('/update_ip', express.urlencoded({ extended: true }), (req, res) => {
 
 app.get('/export', (req, res) => {
   if (!originalData.length) return res.status(400).send('No data');
-  const now = Date.now();
   const rows = originalData.map((r, i) => {
     const srv = servers[i] || {};
     return [


### PR DESCRIPTION
## Summary
- remove leftover `now` variable around the `/export` endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_685281ba5cb0832fb33dd8fd9ff4d337