### PR TITLE
Add Node engine specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ created in the same directory with the suffix `_export.csv`.
 
 ## Node.js version
 
-An Express implementation is available in `server.js`.
+An Express implementation is available in `server.js` and requires Node.js 20 or newer.
 
 1. Install dependencies
    ```bash

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=20"
+  },
   "type": "commonjs",
   "dependencies": {
     "csv-parser": "^3.0.0",


### PR DESCRIPTION
## Summary
- enforce Node.js 20+ in `package.json`
- document required Node version in README

## Testing
- `npm test` *(fails: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_685289022878832f90ae6fe4bc757b59